### PR TITLE
Export csv date fix

### DIFF
--- a/ClimateData/export_csv.py
+++ b/ClimateData/export_csv.py
@@ -138,7 +138,6 @@ def export_csv_split_months_by_county(df_list, state_dict, date_range, data_type
                         temperature_data_values.append(np.nan)
 
                 # Process data
-                #[x, y, x_dates] = get_xy_data_for_months(county_df, begin_year, end_year, month_cell_index)
                 [x, y, x_dates] = get_xy_data_for_months(county_df, begin_year_from_df, end_year, month_cell_index)
 
                 # Get polynomial coefficients


### PR DESCRIPTION
**Issue:** If year inputted is before 1895 (temp data) or 1897 (elevation data), then export csv would crash.
**Test cases:** 
1. Split months with dates 01/1880 - 01/2022 , Temp Data Type
2. Split months with dates 01/1700 - 06/2022 w/ Alaska county, Temp Data Type
3. Split months with dates 01/1800 - 01/2022 , Elevation Data Type

